### PR TITLE
Enable Blackfire by default

### DIFF
--- a/.magento.app.yaml
+++ b/.magento.app.yaml
@@ -17,6 +17,7 @@ runtime:
         - redis
         - xsl
         - json
+        - blackfire
 
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed


### PR DESCRIPTION
Blackfire can be configured by defining the following Variables:

 * `env:BLACKFIRE_SERVER_ID`
 * `env:BLACKFIRE_SERVER_TOKEN`

It is safe to have Blackfire enabled even if it is not yet configured. Since Blackfire is included with MECE it makes sense to have this enabled out of the box, especially since it makes it a lot easier for the user to enable and configure Blackfire.