### PR TITLE
Don't hardcode absolute paths in `php.ini`

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -23,7 +23,7 @@ realpath_cache_ttl = 7200
 ;
 ; Multi store support
 ;
-auto_prepend_file = /app/magento-vars.php
+auto_prepend_file = ${MAGENTO_CLOUD_APP_DIR}/magento-vars.php
 
 :
 ; This feature was DEPRECATED in PHP 5.6.0, and REMOVED as of PHP 7.0.0.


### PR DESCRIPTION
This makes it easier to port the `php.ini` configuration between environments, and especially to MECE.