### PR TITLE
increase default disk usage

### DIFF
--- a/.magento.app.yaml
+++ b/.magento.app.yaml
@@ -62,7 +62,7 @@ web:
 
 
 # The size of the persistent disk of the application (in MB).
-disk: 2048
+disk: 20480
 
 # The mounts that will be performed when the package is deployed.
 mounts:

--- a/.magento/services.yaml
+++ b/.magento/services.yaml
@@ -4,11 +4,11 @@
 
 mysql:
     type: mysql:10.0
-    disk: 2048
+    disk: 10240
 
 redis:
     type: redis:3.0
 
 solr:
     type: solr:4.10
-    disk: 1024
+    disk: 5120


### PR DESCRIPTION
This is resulting in a lot of MECE customers hitting their disk usage early on and raising critical support tickets. Is there a more sane default?