### PR TITLE
Add skeleton .blackfire.yml

### DIFF
--- a/.blackfire.yml
+++ b/.blackfire.yml
@@ -1,0 +1,27 @@
+tests:
+    Pages should be fast enough:
+        path: /.*
+        assertions:
+            - main.wall_time < 850ms
+            - main.io < 500ms
+            - main.cpu_time < 500ms
+    Pages should not consume too much memory:
+        path: /.*
+        assertions:
+            - main.memory < 50M
+            - main.peak_memory < 75M
+    Homepage should not do too many SQL queries:
+        path: /
+        assertions:
+            - metrics.sql.queries.count <= 12
+    Checkout pages should be light:
+        path: /checkout/.*
+        assertions:
+            - metrics.output.network_out < 100KB
+
+scenarios:
+    Home:
+        - /
+
+    Cart:
+        - /checkout/cart/


### PR DESCRIPTION
During the MECE Blackfire Technical Onboarding calls we have each customer add this skeleton file to their project. This incurs the cost of communicating what needs to be done, how to do it, in some cases ensuring the code is actually checked out, that the person sharing the screen has git permission to push, and then waiting for the file to deploy.

In an ideal situation, this skeleton file should just be there for everyone. All Magento Cloud customers will eventually have this file anyway. This will save a lot of onboarding time.