### PR TITLE
MAGECLOUD-1273: The bin/magento support:backup:code command is broken on 2.2.x

### DIFF
--- a/update/.htaccess
+++ b/update/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all


### PR DESCRIPTION
### Description
Fix issue with broken bin/magento support:backup:code command because the "update" directory is missed on cloud:

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-1273

### Manual testing scenarios
* install magento on cloud
* connect to cloud by ssh
* run command `php bin/magento support:backup:code`
* command run without errors
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
