### PR TITLE
MAGECLOUD-1381: Removing duplicate cron:run command [2.0.9]

### DIFF
--- a/.magento.app.yaml
+++ b/.magento.app.yaml
@@ -80,5 +80,5 @@ hooks:
 # Default Magento 2 cron jobs
 crons:
     cronrun:
-        spec: "*/5 * * * *"
-        cmd: "php bin/magento cron:run && php bin/magento cron:run"
+        spec: "* * * * *"
+        cmd: "php bin/magento cron:run"

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ deploy: |
 ```
 crons:
         cronrun:
-            spec: "*/5 * * * *"
-            cmd: "php bin/magento cron:run && php bin/magento cron:run"
+            spec: "* * * * *"
+            cmd: "php bin/magento cron:run"
 ```
 
 ### `composer.json`


### PR DESCRIPTION
[MAGECLOUD-1381: Removing duplicate cron:run command](https://magento2.atlassian.net/browse/MAGECLOUD-1381)

### Description
For normal operation of Magento 2 the cli command ```php bin/magento cron: run``` should be run every minute

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)