### PR TITLE
MAGECLOUD-1743: The directory 'm2-hotfixes' should not be ignored by Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 !/composer.json
 !/composer.lock
 !/magento-vars.php
+!/m2-hotfixes
+!/m2-hotfixes/**
 !/php.ini
 !/update
 !/update/.htaccess


### PR DESCRIPTION
### Description
Git rules about not to ignore the directory "m2-hotfixes"