### PR TITLE
MAGECLOUD-1767: Add .magento.env.yaml to all template with 2.1.x versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !/.blackfire.yml
 !/.gitignore
 !/.magento.app.yaml
+!/.magento.env.yaml
 !/.magento
 !/.magento/**
 /.magento/local

--- a/.magento.env.yaml
+++ b/.magento.env.yaml
@@ -1,0 +1,61 @@
+#stage:
+#  global:
+#      SCD_THREADS: 1
+#      SCD_EXCLUDE_THEMES: ""
+#      SKIP_SCD: false
+#      VERBOSE_COMMANDS: ""
+#  build:
+#      SCD_COMPRESSION_LEVEL: 6
+#  deploy:
+#      SCD_COMPRESSION_LEVEL: 4
+#      QUEUE_CONFIGURATION: { }
+#      SEARCH_CONFIGURATION: { }
+#      CRON_CONSUMERS_RUNNER: { }
+#      CACHE_CONFIGURATION: { }
+#      SESSION_CONFIGURATION: { }
+#      CLEAN_STATIC_FILES: true
+#      STATIC_CONTENT_SYMLINK: true
+#      UPDATE_URLS: true
+#      GENERATED_CODE_SYMLINK: true
+#log:
+#  slack:
+#      token: "<your-slack-token>"
+#      channel: "<your-slack-channel>"
+#      username: "SlackHandler"
+#      min_level: "info"
+#  email:
+#      to: <your-email>
+#      from: <your-email>
+#      subject: "Log notification from Magento Cloud"
+#      min_level: "notice"
+#  syslog:
+#      ident: "<syslog-ident>"
+#      facility: 8 # http://php.net/manual/en/network.constants.php
+#      min_level: "info"
+#      logopts: <syslog-logopts>
+#  syslog_udp:
+#      host: "<syslog-host>"
+#      port: <syslog-port>
+#      facility: 8  # http://php.net/manual/en/network.constants.php
+#      ident: "<syslog-ident>"
+#      min_level: "info"
+#  gelf:
+#      min_level: "info"
+#      use_default_formatter: true
+#      additional: # Some additional information for each log message
+#          project: "<some-project-id>"
+#          app_id: "<some-app-id>"
+#      transport:
+#          http:
+#              host: "<http-host>"
+#              port: <http-port>
+#              path: "<http-path>"
+#              connection_timeout: 60
+#           tcp:
+#              host: "<tcp-host>"
+#              port: <tcp-port>
+#              connection_timeout: 60
+#          udp:
+#              host: "<udp-host>"
+#              port: <udp-port>
+#              chunk_size: 1024


### PR DESCRIPTION
[MAGECLOUD-1767: Add .magento.env.yaml to all template with 2.1.x versions](https://magento2.atlassian.net/browse/MAGECLOUD-1767)