### PR TITLE
MAGECLOUD-2030: The 'build_options.ini' file must exist in the .gitignore of Magento Cloud Base Template file as '!/build_options.ini'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 !/app/i18n/**
 !/auth.json
 !/auth.json.sample
+!/build_options.ini
 !/composer.json
 !/composer.lock
 !/magento-vars.php


### PR DESCRIPTION
The 'build_options.ini' file must exist in the .gitignore of Magento Cloud Base Template file as '!/build_options.ini'