### PR TITLE
MAGECLOUD-2030: The 'build_options.ini' file must exist in the .gitignore of Magento Cloud Base Template file as '!/build_options.ini'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 !/app/etc/config.php
 !/app/i18n/**
 !/auth.json
+!/build_options.ini
 !/composer.json
 !/composer.lock
 !/magento-vars.php


### PR DESCRIPTION
The 'build_options.ini' file must exist in the .gitignore of Magento Cloud Base Template file as '!/build_options.ini'