### PR TITLE
MAGECLOUD-1911: Use correct hooks in templates

### DIFF
--- a/.magento.app.yaml
+++ b/.magento.app.yaml
@@ -70,14 +70,16 @@ mounts:
     "pub/media": "shared:files/media"
     "pub/static": "shared:files/static"
 
-# The hooks executed at various points in the lifecycle of the application.
 hooks:
     # We run build hooks before your application has been packaged.
     build: |
-        php ./vendor/bin/m2-ece-build
+        php ./vendor/bin/ece-tools build
     # We run deploy hook after your application has been deployed and started.
     deploy: |
-        php ./vendor/bin/m2-ece-deploy
+        php ./vendor/bin/ece-tools deploy
+    # We run post deploy hook to clean and warm the cache.  Available with ECE-Tools 2002.0.10
+    post_deploy: |
+        php ./vendor/bin/ece-tools post-deploy
 
 # Default Magento 2 cron jobs
 crons:

--- a/.magento.app.yaml
+++ b/.magento.app.yaml
@@ -77,7 +77,7 @@ hooks:
     # We run deploy hook after your application has been deployed and started.
     deploy: |
         php ./vendor/bin/ece-tools deploy
-    # We run post deploy hook to clean and warm the cache.  Available with ECE-Tools 2002.0.10
+    # We run post deploy hook to clean and warm the cache. Available with ECE-Tools 2002.0.10.
     post_deploy: |
         php ./vendor/bin/ece-tools post-deploy
 


### PR DESCRIPTION
1. Moving hooks to use vendor/bin/ece-tools
1. Adding post-deploy hook