### PR TITLE
Add missing dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,15 @@
     "require": {
         "magento/magento-cloud-metapackage": ">=2.2.4 <2.2.5"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~6.2.0",
+        "squizlabs/php_codesniffer": "3.2.2",
+        "phpmd/phpmd": "@stable",
+        "pdepend/pdepend": "2.5.2",
+        "friendsofphp/php-cs-fixer": "~2.2.1",
+        "lusitanian/oauth": "~0.8.10",
+        "sebastian/phpcpd": "2.0.4"
+    },
     "config": {
         "use-include-path": true
     },


### PR DESCRIPTION
Cloud edition "composer install" does not fetch the --dev dependencies of required packages.
That is the desired behavior of composer.
Every meta-package must resolve the dev dependencies directly.

Please have a look into symfony skeleton project for example: https://github.com/symfony/website-skeleton/blob/4.0/composer.json#L29