### PR TITLE
MAGECLOUD-2350: Problem with images after upgrade from 2.2.4 to 2.3

### DIFF
--- a/.magento.app.yaml
+++ b/.magento.app.yaml
@@ -51,7 +51,7 @@ web:
             root: "pub/media"
             allow: true
             scripts: false
-            passthru: "/index.php"
+            passthru: "/get.php"
         "/static":
             root: "pub/static"
             allow: true


### PR DESCRIPTION
Fix problem with product images after upgrading Magento from 2.2.4 to 2.3
https://magento2.atlassian.net/browse/MAGECLOUD-2350