### PR TITLE
MAGECLOUD-2363: Compilation & SCD on Build should be Separate from File Transfer

### DIFF
--- a/.magento.app.yaml
+++ b/.magento.app.yaml
@@ -75,7 +75,8 @@ mounts:
 hooks:
     # We run build hooks before your application has been packaged.
     build: |
-        php ./vendor/bin/ece-tools build
+        php ./vendor/bin/ece-tools build:generate
+        php ./vendor/bin/ece-tools build:transfer
     # We run deploy hook after your application has been deployed and started.
     deploy: |
         php ./vendor/bin/ece-tools deploy


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-2363
Split build process into two separate commands:
- Building code & SCD
- Moving everything from build server to final destination