### PR TITLE
Add long-term caching headers for media and static assets

### DIFF
--- a/.magento.app.yaml
+++ b/.magento.app.yaml
@@ -51,11 +51,13 @@ web:
             root: "pub/media"
             allow: true
             scripts: false
+            expires: 1y
             passthru: "/get.php"
         "/static":
             root: "pub/static"
             allow: true
             scripts: false
+            expires: 1y
             passthru: "/front-static.php"
             rules:
                 ^/static/version\d+/(?<resource>.*)$:


### PR DESCRIPTION
Interestingly, long-term caching for media and static assets was never enabled by default. Enabling this has a dramatic effect on the user experience, especially in the admin area. This is only safe when static content signing is enabled, but it is current force enabled as part of the ECE tools.