### PR TITLE
MAGECLOUD-2971: Magento 2.1.16 - PHP 7.1 is not Compatible on Cloud Update php version

### DIFF
--- a/.magento.app.yaml
+++ b/.magento.app.yaml
@@ -6,7 +6,7 @@
 name: mymagento
 
 # The toolstack used to build the application.
-type: php:7.0
+type: php:7.1
 build:
     flavor: composer
 


### PR DESCRIPTION
Update php version to 7.1