### PR TITLE
MAGECLOUD-3196: Add ElasticSearch 6.x Support to Cloud

### DIFF
--- a/.magento.app.yaml
+++ b/.magento.app.yaml
@@ -26,6 +26,7 @@ runtime:
 relationships:
     database: "mysql:mysql"
     redis: "redis:redis"
+    elasticsearch: "elasticsearch:elasticsearch"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/.magento/services.yaml
+++ b/.magento/services.yaml
@@ -9,3 +9,6 @@ mysql:
 redis:
     type: redis:3.0
 
+elasticsearch:
+    type: elasticsearch:6.5
+    disk: 1024


### PR DESCRIPTION
Added ElasticSearch in default configuration