### PR TITLE
Add sodium extension for PHP

### DIFF
--- a/.magento.app.yaml
+++ b/.magento.app.yaml
@@ -18,6 +18,7 @@ runtime:
         - json
         - blackfire
         - newrelic
+        - sodium
 
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed


### PR DESCRIPTION
Based on:
this article: https://community.magento.com/t5/Magento-DevBlog/Required-libsodium-upgrade-for-latest-Magento-release/ba-p/134808 
this issue: https://github.com/magento/magento2/issues/23405. 


We should add the `sodium` library.