### PR TITLE
MAGECLOUD-3243: Add PHP container script

### DIFF
--- a/bin/php-docker
+++ b/bin/php-docker
@@ -1,0 +1,4 @@
+#!/bin/bash
+version="$1"
+shift
+docker run --rm -it -e "MAGENTO_ROOT=/app" -v "$(pwd)":/app -v ~/.composer/cache:/root/.composer/cache "magento/magento-cloud-docker-php:${version}-cli" "$@"

--- a/bin/php-docker
+++ b/bin/php-docker
@@ -1,4 +1,46 @@
 #!/bin/bash
-version="$1"
-shift
-docker run --rm -it -e "MAGENTO_ROOT=/app" -v "$(pwd)":/app -v ~/.composer/cache:/root/.composer/cache "magento/magento-cloud-docker-php:${version}-cli" "$@"
+
+set -e
+
+USAGE="Magento PHP Docker
+
+\033[33mArguments:\033[0m
+  7.2           run a command in a PHP 7.2 container
+  7.3           run a command in a PHP 7.3 container
+
+\033[33mOptions:\033[0m
+  -h            show this help text
+
+\033[33mExample usage:\033[0m
+  bin/php-docker 7.3 composer install
+  bin/php-docker 7.3 vendor/bin/ece-docker build:compose\n"
+
+if [ ${#@} -ne 0 ]; then
+    for arg in "$@"; do
+        if [ "${arg#"-h"}" = "" ]; then
+            printf "$USAGE"
+            exit 0;
+        fi
+    done
+fi;
+
+php-container ()
+{
+    local version="$1"
+    shift
+    docker run --rm -it -e "MAGENTO_ROOT=/app" -v "$(pwd)":/app -v ~/.composer/cache:/root/.composer/cache "magento/magento-cloud-docker-php:${version}-cli" "$@"
+}
+
+case "$1" in
+    7.2)
+        shift
+        php-container 7.2 "$@"
+        ;;
+    7.3)
+        shift
+        php-container 7.3 "$@"
+        ;;
+    *)
+        printf "$USAGE"
+        exit 0;
+esac


### PR DESCRIPTION
### Description
Currently, installing the Magento Cloud template requires PHP to be installed on one's host system. This change provides commands which use Docker to allow things such as `composer install` and `vendor/bin/ece-tools`. This happens with only Docker and Bash installed, and does not require PHP on the host system.

### Issues resolved
MAGECLOUD-3243
https://github.com/magento/magento-cloud-docker/issues/47
