### PR TITLE
MCLOUD-2649: [opcache] Disable timestamps validation

### DIFF
--- a/op-exclude.txt
+++ b/op-exclude.txt
@@ -2,4 +2,3 @@
 /app/*/etc/env.php
 /app/etc/config.php
 /app/etc/env.php
-

--- a/op_exclude.txt
+++ b/op_exclude.txt
@@ -1,0 +1,5 @@
+/app/*/app/etc/config.php
+/app/*/etc/env.php
+/app/etc/config.php
+/app/etc/env.php
+

--- a/php.ini
+++ b/php.ini
@@ -44,5 +44,4 @@ session.gc_probability = 1
 ; Setup opcache configuration
 ;
 opcache.validate_timestamps = 0
-opcache.blacklist_filename="${MAGENTO_CLOUD_APP_DIR}/op_exclude.txt"
-
+opcache.blacklist_filename="${MAGENTO_CLOUD_APP_DIR}/op-exclude.txt"

--- a/php.ini
+++ b/php.ini
@@ -39,3 +39,10 @@ max_input_vars = 10000
 ; Setup the session garbage collector
 ;
 session.gc_probability = 1
+
+;
+; Setup opcache configuration
+;
+opcache.validate_timestamps = 0
+opcache.blacklist_filename="${MAGENTO_CLOUD_APP_DIR}/op_exclude.txt"
+


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added exclude list for opCache and disabled timestamps validations.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://jira.corp.magento.com/browse/MCLOUD-2649

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Check that php -i shows `opcache.blacklist_filename => /app/*/op_exclude.txt => /app/*/op_exclude.txt` and `opcache.validate_timestamps => Off => Off`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
