### PR TITLE
add op-exclude.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 !/README.md
 !/.github
 !/.github/*
+!/op-exclude.txt


### PR DESCRIPTION
### Description
`op-exclude.txt` is a configuration file that should be tracked in a project repository. (Similar to `php.ini`) The `.gitignore` file should explicitly include it.


### Manual testing scenarios
1. create magento cloud project
2. init a git repository
3. observe that git is trying to track `op-exclude.txt` by default 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
