### PR TITLE
Update php.ini to increase interned_strings_buffer

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -42,3 +42,4 @@ opcache.validate_timestamps = 0
 opcache.blacklist_filename="${MAGENTO_CLOUD_APP_DIR}/op-exclude.txt"
 opcache.max_accelerated_files=16229
 opcache.consistency_checks=0
+opcache.interned_strings_buffer=32


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Whilst monitoring the opcache with a single instance of M2, I have noticed that this value is set too low and the buffer overflows. To resolve this and improve performance, the value can be increased.

(The amount of memory for interned strings in Mbytes.)
opcache.interned_strings_buffer=32

More information on this from [Blackfire](https://blog.blackfire.io/cache-information.html)

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Monitor opcache without this change, you will see that the buffer becomes full and overflows.
2. Add the change and perform the same monitoring. The buffer will no longer overflow.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
