### PR TITLE
Increase application disk size

### DIFF
--- a/.magento.app.yaml
+++ b/.magento.app.yaml
@@ -64,7 +64,7 @@ web:
                     passthru: "/static/$resource"
 
 # The size of the persistent disk of the application (in MB).
-disk: 5120
+disk: 15360
 
 # The mounts that will be performed when the package is deployed.
 mounts:


### PR DESCRIPTION
The new minimum required application disk size for Magento Cloud is 11GB.
Setting default to 15GB per discussions with product team.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento-cloud#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
