### PR TITLE
Set 10M for realpath_cache_size in php.ini

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -13,7 +13,7 @@ zlib.output_compression = on
 ;
 ; Increase realpath cache size
 ;
-realpath_cache_size = 32k
+realpath_cache_size = 10M
 
 ;
 ; Increase realpath cache ttl


### PR DESCRIPTION
### Description
Regarding this article, https://support.magento.com/hc/en-us/articles/360045176771-Realpath-cache-size-best-practice, realpath_cache_size should be set a 10M


### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
